### PR TITLE
Removes package vulnerabilities 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var debug = require('debug')('recursive-uglifyjs');
-var uglify = require('uglify-js').uglify;
+var uglify = require('uglify-js');
 var finder = require('finder-on-steroids');
 
 /**
@@ -78,7 +78,7 @@ function recursiveUglifyJS(directory, callback) {
         //minify the code
         var code;
         try {
-           code = uglify.gen_code(source);
+           code = uglify.minify(source).code;
         } catch (error) {
           return finished(file, error);
         }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var debug = require('debug')('recursive-uglifyjs');
-var uglify = require('uglify-js');
+var uglify = require('uglify-js').uglify;
 var finder = require('finder-on-steroids');
 
 /**
@@ -78,7 +78,7 @@ function recursiveUglifyJS(directory, callback) {
         //minify the code
         var code;
         try {
-           code = uglify.minify(source, {fromString: true}).code;
+           code = uglify.gen_code(source);
         } catch (error) {
           return finished(file, error);
         }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "debug": "^2.1.0",
-    "finder-on-steroids": "^0.3.1",
-    "uglify-js": "~2.4.15"
+    "finder-on-steroids": "^0.4.0",
+    "uglify-js": "^3.3.28"
   },
   "bin": {
     "recursive-uglifyjs": "./cli/cmd.js"


### PR DESCRIPTION
The UglifyJS version `~2.4.15` has a vulnerability marked as high priority when running `npm audit`. This PR has updated the uglifyjs dependency and removes the vulnerability error.